### PR TITLE
Handle IP API failures with fallback

### DIFF
--- a/server/ipapi.js
+++ b/server/ipapi.js
@@ -3,6 +3,10 @@ const https = require('https');
 module.exports = function ipapi(ip) {
   return new Promise((resolve, reject) => {
     const req = https.get(`https://ipapi.co/${ip}/json/`, res => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`ipapi status ${res.statusCode}`));
+      }
       let data = '';
       res.on('data', chunk => (data += chunk));
       res.on('end', () => {

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,8 @@ const express = require('express');
 const net = require('net');
 const path = require('path');
 const helmet = require('helmet');
+const ipapi = require('./ipapi');
+const iplocate = require('./iplocate');
 
 
 const app = express();
@@ -69,7 +71,16 @@ app.get('/api/ip', (req, res) => res.json({ ok: true, ip: getClientIp(req) }));
 app.get('/api/ipinfo', async (req, res) => {
   try {
     const ip = req.query.ip || getClientIp(req);
-
+    let data;
+    try {
+      data = await ipapi(ip);
+    } catch (err) {
+      try {
+        data = await iplocate(ip);
+      } catch (err2) {
+        return res.status(502).json({ ok: false, error: 'lookup_failed' });
+      }
+    }
     res.json({ ok: true, data });
   } catch (e) {
     res.status(500).json({ ok: false, error: 'lookup_failed' });

--- a/web/app.js
+++ b/web/app.js
@@ -53,7 +53,16 @@ async function fetchIp() {
 
 async function fetchIpInfo(ip) {
   try {
-
+    const j = await (await fetch(`/api/ipinfo?ip=${encodeURIComponent(ip)}`)).json();
+    if (j.ok) {
+      const d = j.data || {};
+      const city = d.city;
+      const region = d.region || d.region_name;
+      const country = d.country_name || d.country;
+      const parts = [city, region, country].filter(Boolean);
+      ipInfoEl.textContent = parts.join(', ') || 'No info.';
+    } else {
+      ipInfoEl.textContent = 'IP info unavailable.';
     }
   } catch {
     ipInfoEl.textContent = 'Failed to load.';


### PR DESCRIPTION
## Summary
- Validate response codes in `ipapi` and reject on non-200 responses
- Fall back to `iplocate` when `ipapi` fails in `/api/ipinfo`
- Display a clear message when IP info lookup fails on the client

## Testing
- `npm test --prefix server` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b42590c5ec8327977fa1f582766c2f