### PR TITLE
Improve IP info lookup error handling

### DIFF
--- a/server/ipapi.js
+++ b/server/ipapi.js
@@ -11,7 +11,11 @@ module.exports = function ipapi(ip) {
       res.on('data', chunk => (data += chunk));
       res.on('end', () => {
         try {
-          resolve(JSON.parse(data));
+          const json = JSON.parse(data);
+          if (json && json.error) {
+            return reject(new Error(json.reason || 'ipapi error'));
+          }
+          resolve(json);
         } catch (err) {
           reject(err);
         }

--- a/server/iplocate.js
+++ b/server/iplocate.js
@@ -7,7 +7,11 @@ module.exports = function iplocate(ip) {
       res.on('data', chunk => (data += chunk));
       res.on('end', () => {
         try {
-          resolve(JSON.parse(data));
+          const json = JSON.parse(data);
+          if (json && json.error) {
+            return reject(new Error(json.reason || 'iplocate error'));
+          }
+          resolve(json);
         } catch (err) {
           reject(err);
         }


### PR DESCRIPTION
## Summary
- Reject error payloads from ipapi/iplocate to avoid misleading IP info

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check ipapi.js`
- `node --check iplocate.js`


------
https://chatgpt.com/codex/tasks/task_e_68b427fe7fa483278e3e3359129a36cf