### PR TITLE
Improve IP info lookup error handling

### DIFF
--- a/server/ipapi.js
+++ b/server/ipapi.js
@@ -11,7 +11,58 @@ module.exports = function ipapi(ip) {
       res.on('data', chunk => (data += chunk));
       res.on('end', () => {
         try {
-          resolve(JSON.parse(data));
+          const json = JSON.parse(data);
+          if (json && json.error) {
+            return reject(new Error(json.reason || 'ipapi error'));
+          }
+          const {
+            ip,
+            city,
+            region,
+            region_code,
+            country_code,
+            country_code_iso3,
+            country_name,
+            country_capital,
+            country_tld,
+            continent_code,
+            in_eu,
+            postal,
+            latitude,
+            longitude,
+            timezone,
+            utc_offset,
+            country_calling_code,
+            currency,
+            currency_name,
+            languages,
+            asn,
+            org,
+          } = json;
+          resolve({
+            ip,
+            city,
+            region,
+            region_code,
+            country_code,
+            country_code_iso3,
+            country_name,
+            country_capital,
+            country_tld,
+            continent_code,
+            in_eu,
+            postal,
+            latitude,
+            longitude,
+            timezone,
+            utc_offset,
+            country_calling_code,
+            currency,
+            currency_name,
+            languages,
+            asn,
+            org,
+          });
         } catch (err) {
           reject(err);
         }

--- a/server/iplocate.js
+++ b/server/iplocate.js
@@ -7,7 +7,35 @@ module.exports = function iplocate(ip) {
       res.on('data', chunk => (data += chunk));
       res.on('end', () => {
         try {
-          resolve(JSON.parse(data));
+          const json = JSON.parse(data);
+          if (json && json.error) {
+            return reject(new Error(json.reason || 'iplocate error'));
+          }
+          const result = {
+            ip: json.ip,
+            city: json.city,
+            region: json.subdivision || json.state || json.region,
+            region_code: json.subdivision_code || json.state_code || json.region_code,
+            country_code: json.country_code,
+            country_code_iso3: json.country_code3,
+            country_name: json.country,
+            country_capital: undefined,
+            country_tld: json.tld,
+            continent_code: json.continent_code,
+            in_eu: json.in_eu,
+            postal: json.postal_code,
+            latitude: json.latitude,
+            longitude: json.longitude,
+            timezone: json.time_zone,
+            utc_offset: json.utc_offset,
+            country_calling_code: json.country_calling_code,
+            currency: json.currency,
+            currency_name: json.currency_name,
+            languages: json.languages,
+            asn: json.asn,
+            org: json.org,
+          };
+          resolve(result);
         } catch (err) {
           reject(err);
         }


### PR DESCRIPTION
## Summary
- Reject error payloads from ipapi/iplocate to avoid misleading IP info
- Normalize geolocation results to the expected ipapi field set

## Testing
- `node --check server/ipapi.js`
- `node --check server/iplocate.js`
- `node --check server/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68b427fe7fa483278e3e3359129a36cf