### PR TITLE
Fix IP info modules to resolve fetched data

### DIFF
--- a/server/ipapi.js
+++ b/server/ipapi.js
@@ -15,7 +15,7 @@ module.exports = function ipapi(ip) {
           if (json && json.error) {
             return reject(new Error(json.reason || 'ipapi error'));
           }
-
+          resolve(json);
         } catch (err) {
           reject(err);
         }

--- a/server/iplocate.js
+++ b/server/iplocate.js
@@ -3,6 +3,10 @@ const https = require('https');
 module.exports = function iplocate(ip) {
   return new Promise((resolve, reject) => {
     const req = https.get(`https://iplocate.io/api/lookup/${ip}`, res => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`iplocate status ${res.statusCode}`));
+      }
       let data = '';
       res.on('data', chunk => (data += chunk));
       res.on('end', () => {
@@ -11,7 +15,7 @@ module.exports = function iplocate(ip) {
           if (json && json.error) {
             return reject(new Error(json.reason || 'iplocate error'));
           }
-
+          resolve(json);
         } catch (err) {
           reject(err);
         }


### PR DESCRIPTION
## Summary
- ensure ipapi and iplocate helpers resolve parsed JSON instead of leaving promises pending
- handle non-200 responses from iplocate for clearer errors

## Testing
- `npm test` (fails: Missing script: "test")
- `curl -s -D - http://localhost:8080/api/ipinfo?ip=8.8.8.8` (fails: lookup_failed)


------
https://chatgpt.com/codex/tasks/task_e_68b42b66608c8327933e2c423433fbcb